### PR TITLE
[BUGFIX] prevent drag selections when lasso is disabled (false)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /test_reports
 /.idea
+/wiki

--- a/selectable.js
+++ b/selectable.js
@@ -414,7 +414,7 @@
 
             // Attach event listeners
             on(this.container, 'mousedown', e.start);
-            on(document, 'mousemove', e.drag);
+
             on(document, 'mouseup', e.end);
             on(document, 'keydown', e.keydown);
             on(document, 'keyup', e.keyup);
@@ -427,7 +427,11 @@
             on(this.container, "touchstart", e.touchstart);
             on(document, "touchend", e.end);
             on(document, "touchcancel", e.end);
-            on(document, "touchmove", e.drag);
+
+            if (this.lasso !== false) {
+                on(document, "touchmove", e.drag);
+                on(document, 'mousemove', e.drag);
+            }
 
             on(window, 'resize', e.recalculate);
             on(window, 'scroll', e.recalculate);

--- a/tests/selectableSpec.js
+++ b/tests/selectableSpec.js
@@ -349,7 +349,8 @@ describe('selectable', function () {
                         toggle: false,
                         lasso: false,
                         classes: {
-                            selected: "test-selected"
+                            selected: "test-selected",
+                            selecting: "test-selecting"
                         }
                     });
                 });
@@ -359,7 +360,7 @@ describe('selectable', function () {
                     var firstNodeExpectation = expect(container.children[0].getAttribute('class')),
                         secondNodeExpectation = expect(container.children[1].getAttribute('class')),
                         lastNodeExpectation = expect(container.children[2].getAttribute('class'));
-                    firstNodeExpectation.not.toContain('test-selecting');
+                    firstNodeExpectation.toContain('test-selecting');
                     firstNodeExpectation.not.toContain('test-selected');
                     secondNodeExpectation.not.toContain('test-selected');
                     secondNodeExpectation.not.toContain('test-selecting');
@@ -370,7 +371,7 @@ describe('selectable', function () {
                     firstNodeExpectation = expect(container.children[0].getAttribute('class'));
                     secondNodeExpectation = expect(container.children[1].getAttribute('class'));
                     lastNodeExpectation = expect(container.children[2].getAttribute('class'));
-                    firstNodeExpectation.not.toContain('test-selecting');
+                    firstNodeExpectation.toContain('test-selecting');
                     secondNodeExpectation.not.toContain('test-selecting');
                     lastNodeExpectation.not.toContain('test-selecting');
 
@@ -378,7 +379,7 @@ describe('selectable', function () {
                     firstNodeExpectation = expect(container.children[0].getAttribute('class'));
                     secondNodeExpectation = expect(container.children[1].getAttribute('class'));
                     lastNodeExpectation = expect(container.children[2].getAttribute('class'));
-                    firstNodeExpectation.not.toContain('test-selecting');
+                    firstNodeExpectation.toContain('test-selecting');
                     firstNodeExpectation.not.toContain('test-selected');
                     secondNodeExpectation.not.toContain('test-selecting');
                     secondNodeExpectation.not.toContain('test-selected');


### PR DESCRIPTION
Hi,

Currently there is no way to disable the laso behaviour, setting it to false would still select items as you move the mouse,
This PR prevents the lasso's mousemove listeners from getting attached, disabling the lasso entirely as a result.

I've added tests to prove the functionality is working as described