### PR TITLE
Allowed to control the plugin on touch devices

### DIFF
--- a/selectable.js
+++ b/selectable.js
@@ -103,6 +103,9 @@
 
                 appendTo: document.body,
 
+                touch: true,
+                toggleTouch: true,
+
                 toggle: false,
                 autoRefresh: true,
 
@@ -169,7 +172,11 @@
             }
 
             if (this.touch) {
-                o.toggle = false;
+                o.toggle = o.toggleTouch;
+            }
+
+            if (!o.touch) {
+                this.touch = false;
             }
 
             this.events = {};
@@ -1014,7 +1021,7 @@
 
                     item.startselected = true;
 
-                    var deselect = (this.touch || o.toggle || cmd) ? isCurrentNode : !isCurrentNode && !shift;
+                    var deselect = (o.toggle || cmd) ? isCurrentNode : !isCurrentNode && !shift;
 
                     if (deselect) {
                         classList.remove(el, o.classes.selected);


### PR DESCRIPTION
**Finally**! You **all** requested this feature! 
This pull request allows users to manipulate their plugin on touch devices!

How to use?

**Standart usage:**
```js
const selectable = new Selectable({
  appendTo: '#content',
});
```

**New usage:**
```js
const selectable = new Selectable({
  touch: false, // Set to false if you want to disable "lasso" toggling items still work!
  toggleTouch: true, // Set to true if you want to toggle or false if not
  appendTo: '#content',
});
```

**`Note! By default plugin works as a previous version! `**
But now you can manipulate it better 👍 