### PR TITLE
Fix elementFromPoint to use clientX/Y instead of pageX/Y

### DIFF
--- a/selectable.js
+++ b/selectable.js
@@ -1262,7 +1262,7 @@
 
                     // the lasso was the event.target so let's get the actual
                     // node below the pointer
-                    node = document.elementFromPoint(evt.pageX, evt.pageY);
+                    node = document.elementFromPoint(evt.clientX, evt.clientY);
 
                     if (!node) {
                         node = this.container;


### PR DESCRIPTION
I noticed that the _end function throws an error if the page is scrolled down far enough. This is because pageX/Y is used in elementFromPoint instead of clientX/Y. elementFromPoint takes coordinates on the viewport, while pageX/Y is relative to the document. ClientX/Y is relative to the viewport so should be used instead.

Great plugin by the way! Works a dream for the most part and so much smoother / better than the JqueryUI version.